### PR TITLE
Angepasste Laufweite für Headlines und font rendering

### DIFF
--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -3,6 +3,12 @@ html, body {
   -webkit-text-size-adjust: 100%;
 }
 
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
 $border: 1px $grey-100 solid;
 
 .header {

--- a/_scss/_typo.scss
+++ b/_scss/_typo.scss
@@ -6,7 +6,7 @@
   font-size: 72px;
   line-height: 116%;
   font-feature-settings: "salt" on;
-  letter-spacing: -.03em;
+  letter-spacing: -.02em;
 
   @media screen and (max-width: 850px) {
     font-size: clamp(25px, 8vw, 42px);
@@ -23,7 +23,7 @@
   font-weight: bold;
   font-size: 72px;
   line-height: 126.4%;
-  letter-spacing: -.03em;
+  letter-spacing: -.02em;
   font-feature-settings: "salt" on;
 
   @media screen and (max-width: 450px) {
@@ -56,7 +56,7 @@
   font-weight: 600;
   font-size: 20px;
   line-height: 28px;
-  letter-spacing: .03em;
+  letter-spacing: .02em;
   font-feature-settings: 'pnum' on, 'lnum' on, "salt" on;
   text-transform: uppercase;
 }
@@ -66,7 +66,7 @@
   font-weight: 600;
   font-size: 52px;
   line-height: 124.4%;
-  letter-spacing: -.03em;
+  letter-spacing: -.02em;
   font-feature-settings: "salt" on;
 
   @media screen and (max-width: 850px) {

--- a/_scss/_typo.scss
+++ b/_scss/_typo.scss
@@ -6,6 +6,7 @@
   font-size: 72px;
   line-height: 116%;
   font-feature-settings: "salt" on;
+  letter-spacing: -.03em;
 
   @media screen and (max-width: 850px) {
     font-size: clamp(25px, 8vw, 42px);
@@ -22,6 +23,7 @@
   font-weight: bold;
   font-size: 72px;
   line-height: 126.4%;
+  letter-spacing: -.03em;
   font-feature-settings: "salt" on;
 
   @media screen and (max-width: 450px) {
@@ -39,6 +41,7 @@
   font-family: "SofiaPro", sans-serif;
   font-weight: bold;
   font-size: 28px;
+  letter-spacing: -.01em;
   line-height: 39px;
   font-feature-settings: "salt" on;
 
@@ -53,6 +56,7 @@
   font-weight: 600;
   font-size: 20px;
   line-height: 28px;
+  letter-spacing: .03em;
   font-feature-settings: 'pnum' on, 'lnum' on, "salt" on;
   text-transform: uppercase;
 }
@@ -62,15 +66,16 @@
   font-weight: 600;
   font-size: 52px;
   line-height: 124.4%;
+  letter-spacing: -.03em;
   font-feature-settings: "salt" on;
 
   @media screen and (max-width: 850px) {
     font-size: clamp(25px, 8vw, 42px);
-    line-height: 134%;
+    line-height: 120%;
   }
   @media screen and (max-width: 450px) {
     font-size: calc(min(8vw, 36px));
-    line-height: 134%;
+    line-height: 120%;
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ layout: default
 <header class="header-hero header">
     {% include navigation.html %}
     <div class="hero-content">
-        <h1 class="heading-hero">The first spatial aware signage development environment</h1>
+        <h1 class="heading-hero">The first spatial aware signage<br>development environment</h1>
         <p class="text-subtitle">You’re working with signage and wayfinding systems? </p>
         <button class="button button-black" onclick="toggleChat()"><span>Let's Chat</span></button>
     </div>


### PR DESCRIPTION
Ich würde vorschlagen die Laufweite bei den größeren Headlines etwas verringern, finde im Standard setting fällt die etwas auseinander.
Hab auch mal eine ein paar Zeilen zum font-smoothing hinzugefügt, die h4 und der body text kommen dadurch meiner Meinung nach dem Design etwas näher, wobei ich es bei der Baskerville eigentlich auch mag, wenn es etwas bolder aussieht. 
Was denkst du @KaiMagnusMueller ?

Im Moment in main:
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/33728002/114628823-cb60d080-9cb7-11eb-9903-512c5dbc24c4.png">
PR:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/33728002/114628803-bdab4b00-9cb7-11eb-8c85-a35680d2d270.png">
